### PR TITLE
bugfix-[supplyAsyncWithCurrentScope can't pass current Scope]

### DIFF
--- a/src/main/java/com/github/phantomthief/scope/ScopeUtils.java
+++ b/src/main/java/com/github/phantomthief/scope/ScopeUtils.java
@@ -14,6 +14,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -69,6 +70,10 @@ public final class ScopeUtils {
             @Nonnull Supplier<T> supplier) {
         return () -> supplyWithExistScope(scope, supplier::get);
     }
+    private static <T> Callable<T> wrapCallableExistScope(@Nullable Scope scope,
+            @Nonnull Supplier<T> supplier) {
+        return () -> supplyWithExistScope(scope, supplier::get);
+    }
 
     public static void runAsyncWithCurrentScope(@Nonnull Runnable runnable,
             @Nonnull Executor executor) {
@@ -84,13 +89,13 @@ public final class ScopeUtils {
     @Nonnull
     public static <U> Future<U> supplyAsyncWithCurrentScope(@Nonnull Supplier<U> supplier,
             @Nonnull ExecutorService executor) {
-        return executor.submit(() -> wrapSupplierExistScope(getCurrentScope(), supplier).get());
+        return executor.submit(wrapCallableExistScope(getCurrentScope(), supplier));
     }
 
     @Nonnull
     public static <U> ListenableFuture<U> supplyAsyncWithCurrentScope(@Nonnull Supplier<U> supplier,
             @Nonnull ListeningExecutorService executor) {
-        return executor.submit(() -> wrapSupplierExistScope(getCurrentScope(), supplier).get());
+        return executor.submit(wrapCallableExistScope(getCurrentScope(), supplier));
     }
 
     /**


### PR DESCRIPTION
When I use this method(ScopeUtils.supplyAsyncWithCurrentScope ) to pass Scope to a new thread, i find it doesn't work.
This method does not pass the Scope of the current thread correctly. The main reason is that Scope.getCurrentScope() is written in a lamda expression, so it is executed in a new thread.
After simple rewriting, the scope can be passed correctly~